### PR TITLE
Add Travis CI building to Github Pages for the site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+dist: xenial
+language: python
+python: 3.7
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/lektor/builds
+
+install:
+  - "pip install -U pip"
+  - "pip install Lektor"
+
+script: "lektor build -v"
+
+deploy:
+  provider: script
+  script: "lektor deploy ghpages"
+  on:
+    branch: master

--- a/star_fleet_tours.lektorproject
+++ b/star_fleet_tours.lektorproject
@@ -3,6 +3,9 @@ name = Star Fleet Tours
 themes = lektor-icon
 url_style = absolute
 
+[servers.ghpages]
+target = ghpages+https://star-fleet-tours/star-fleet-tours-website
+
 [theme_settings]
 title = Star✦Fleet Tours
 content_lang = en-US


### PR DESCRIPTION
Adds Travis CI builds and GH pages deployment to generate a live preview of the site.