### PR TITLE
Add launch countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ The underlying theme, [Lektor-Icon](https://spyder-ide.github.io/lektor-icon/), 
 See the Lektor-Icon [license](https://github.com/spyder-ide/lektor-icon/blob/master/LICENSE.txt) and [Notices](https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt) for more details.
 Photos and graphics created or commissioned by us are released under the CC-BY-SA 4.0, while those created by others are used with permission and may be covered by other licenses.
 See the [LICENSE.txt](https://github.com/star-fleet-tours/star-fleet-tours-website/blob/master/LICENSE.txt) in the root of the repository for the full text of the CC-BY-SA 4.0.
+
+
+## Launch countdown override
+
+The landing page and the tickets page can both display a countdown to an upcoming launch. This defaults to automatically retrieving and display the next SpaceX launch from Florida as appropriate. If you need to do something different, edit `assets/static/js/custom-scripts.js` to specify a `missionOverride`:
+
+```javascript
+const missionOverride = {
+    missionName: "Spacecow",
+    launchAt: 1234567890 // the UNIX timestamp of the projected T-0 time
+};
+```
+
+The countdowns display only if the mission is in the near future. To prevent countdown display entirely, specify a mission override with `launchAt: 0`.

--- a/assets/static/css/custom-styles.css
+++ b/assets/static/css/custom-styles.css
@@ -26,7 +26,8 @@ h1,
 #generic-page h2,
 #blog-main-title h1,
 .blog-post h1,
-.blog-post .blog-index-header .row h1 {
+.blog-post .blog-index-header .row h1,
+.launch-countdown-mission-name {
   font-family: "bitsumishiregular", Raleway, "DejaVu Sans", "Open Sans", "Liberation Sans", Helvetica, Arial, sans-serif;
 }
 
@@ -141,4 +142,47 @@ h1,
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+/* A container for the launch countdown on the landing page's hero block */
+.hero-countdown-container {
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+/* A container for the launch countdown within a normal page body */
+#page-body-countdown-container {
+}
+
+/* The launch countdown box itself */
+.launch-countdown {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 0.6em;
+  padding: 1em;
+  width: 22em;
+  margin: 1.5em auto;
+  text-align: center;
+}
+
+/* The text within the launch countdown box */
+.launch-countdown-mission-name {
+  margin: 0 0 0.5em;
+  font-size: 1.5rem;
+}
+h3.launch-countdown-clock {
+  margin: 0 !important;
+  font-size: 3rem;
+  font-variant-numeric: tabular-nums;
+  /* Raleway does not support tabular-nums, which makes the countdown bounce around */
+  font-family: Inconsolata, Consolas, "DejaVu Sans Mono", "Liberation Mono", monospace;
+}
+.launch-countdown-clock::before {
+  content: "T-";
+  opacity: 0.5;
+}
+
+/* Hide the mission name on when we're embedded in the tickets page */
+#page-body-countdown-container .launch-countdown-mission-name {
+  display: none;
 }

--- a/assets/static/js/custom-scripts.js
+++ b/assets/static/js/custom-scripts.js
@@ -11,6 +11,16 @@ https://opensource.org/licenses/MIT
 
     'use strict';
 
+    // We can retrieve the upcoming SpaceX launch from an unofficial API and display it
+    // automatically. If you want to override this behavior, specify a missionOverride here:
+    //
+    //   const missionOverride = {
+    //       missionName: "Spacecow",
+    //       launchAt: 1234567890 // the UNIX timestamp of the projected T-0 time
+    //   };
+    //
+    // Otherwise, specify the absence of a missionOverride:
+    const missionOverride = null;
 
     // Style all "star" symbols
     var styleStarGlyph = function() {
@@ -23,10 +33,124 @@ https://opensource.org/licenses/MIT
         })
     };
 
+    // Display a launch countdown in the hero section of the main page, if appropriate.
+    function initializeLaunchCountdown() {
+        const hero = $(".hero-section#section-home")[0];
+        const pageBodyCountdownContainer = document.getElementById("page-body-countdown-container");
+        if (!hero && !pageBodyCountdownContainer) {
+            // We have nowhere to put the countdown
+            return;
+        }
+
+        if (missionOverride === null) {
+            fetchAndDisplaySpacexLaunchCountdown({hero, pageBodyCountdownContainer});
+        } else {
+            const {missionName, launchAt} = missionOverride;
+            displayLaunchCountdown({hero, pageBodyCountdownContainer, missionName, launchAt});
+        }
+    }
+
+    function fetchAndDisplaySpacexLaunchCountdown({hero, pageBodyCountdownContainer}) {
+        function flightLaunchesFromFlorida(flight) {
+            return ["ksc_lc_39a", "ccafs_slc_40"].includes(flight.launch_site.site_id);
+        }
+
+        // List the upcoming launches:
+        //   https://docs.spacexdata.com/?version=latest#e001c501-9c09-4703-9e29-f91fbbf8db7c
+        //   https://github.com/r-spacex/SpaceX-API
+        fetch("https://api.spacexdata.com/v3/launches/upcoming?limit=5&sort_by=launch_date_utc")
+            // Parse the response
+            .then((resp) => resp.json())
+            // Pick the first flight launching from Florida
+            .then((flights) => flights.filter(flightLaunchesFromFlorida)[0])
+            .then((flight) => {
+                // Do nothing if there is no upcoming launch
+                if (flight === null) {
+                    return;
+                }
+
+                // Fish out some attributes
+                const missionName = flight.mission_name;
+                const launchAt = flight.launch_date_unix;
+
+                displayLaunchCountdown({hero, pageBodyCountdownContainer, missionName, launchAt});
+            });
+        // N.B.: the lack of error handling is intentional
+        // This countdown is a nice-to-have, and not a reason to attract attention on failure
+    }
+
+    function displayLaunchCountdown({hero, pageBodyCountdownContainer, missionName, launchAt}) {
+        // How far in the future is this launch?
+        const now = (new Date()).getTime() / 1000;
+        if (now < launchAt - 14*86400) {
+            // More than two weeks to go
+            // Countdowns this far out aren't exciting, so do nothing
+            return;
+        } else if (now > launchAt) {
+            // This "upcoming" launch already happened?
+            // Either the data is wrong or the user has a bad clock, so do nothing
+            return;
+        }
+
+        // Launch is reasonably imminent
+        // Display the launch countdown
+
+        // Make some DOM elements
+        let countdownContainerDiv;
+        if (hero) {
+            countdownContainerDiv = document.createElement("div");
+            countdownContainerDiv.className = "hero-countdown-container";
+        } else {
+            countdownContainerDiv = pageBodyCountdownContainer;
+        }
+
+        const countdownDiv = document.createElement("div");
+        countdownDiv.className = "launch-countdown";
+        countdownContainerDiv.appendChild(countdownDiv);
+
+        const missionNameHeading = document.createElement("h3");
+        missionNameHeading.className = "launch-countdown-mission-name";
+        missionNameHeading.innerText = missionName + " launch:";
+        countdownDiv.appendChild(missionNameHeading);
+
+        const countdownClockHeading = document.createElement("h3");
+        countdownClockHeading.className = "launch-countdown-clock";
+        countdownDiv.appendChild(countdownClockHeading);
+
+        let interval = null;
+
+        function tick() {
+            const now = Math.floor((new Date()).getTime() / 1000);
+            const delta = launchAt - now;
+            if (delta < 0) {
+                // Stop counting, and remove the countdown
+                clearInterval(interval);
+                countdownContainerDiv.parent.removeChild(countdownContainerDiv);
+                return;
+            }
+
+            const hours = Math.floor(delta / 3600);
+            const minutes = Math.floor((delta % 3600) / 60);
+            const seconds = delta % 60;
+            countdownClockHeading.innerText = [
+                hours.toString().padStart(2, "0"),
+                minutes.toString().padStart(2, "0"),
+                seconds.toString().padStart(2, "0"),
+            ].join(":");
+        }
+        interval = setInterval(tick, 100);
+        tick();
+
+        if (hero) {
+            // Attach our elements to the page
+            hero.appendChild(countdownContainerDiv);
+        }
+    }
 
     // Document on load
     $(function(){
         styleStarGlyph();
+        initializeLaunchCountdown();
     });
 
 }());

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -10,6 +10,8 @@ full_title: Falcon Heavy STP-2 Mission
 ---
 body:
 
+<div id="page-body-countdown-container"></div>
+
 <img src="/current/fh-twin-booster-landing.jpg" alt="Photograph of the twin Falcon Heavy boosters landing from the FH demo mission" style="float: left; margin-left: 0px; margin-right: 40px; margin-top: 5px; margin-bottom: 20px;">
 
 As of June 7, the Falcon Heavy STP-2 launch is scheduled for **Monday, June 24 at 11:30 PM EDT (Tuesday, June 25 at 03:30 UTC)** from historic LC-39A at Kennedy Space Center near Cape Canaveral, Florida.

--- a/star_fleet_tours.lektorproject
+++ b/star_fleet_tours.lektorproject
@@ -28,6 +28,7 @@ content_security_policy = true
 content_security_policy_frame_src =
 content_security_policy_script_src =
 content_security_policy_style_src =
+content_security_policy_connect_src = https://api.spacexdata.com
 loader_enable = false
 nav_logo_path =
 nav_logo_text = Star✦Fleet Tours


### PR DESCRIPTION
This PR adds a launch countdown to the landing page:

<img width="1403" alt="Screen Shot 2019-06-18 at 6 50 18 PM" src="https://user-images.githubusercontent.com/118362/59727236-7efef380-91fa-11e9-9f27-719c15b9aab0.png">

The launch information is sourced from the [unofficial SpaceX API](https://github.com/r-spacex/SpaceX-API), so it will update without intervention for delays, scrubs, or successful launches.

This changeset depends on https://github.com/star-fleet-tours/lektor-icon/pull/1.