### PR TITLE
Update site for take 2 of Artemis 1 launch viewing trip and scrub/refund policy

### DIFF
--- a/assets/static/js/custom-scripts.js
+++ b/assets/static/js/custom-scripts.js
@@ -22,7 +22,7 @@ https://opensource.org/licenses/MIT
     // Otherwise, specify the absence of a missionOverride:
     const missionOverride = {
         missionName: "NASA SLS Artemis 1 Launch",
-        launchAt: 1661776380, // the UNIX timestamp of the projected T-0 time
+        launchAt: 1662221820, // the UNIX timestamp of the projected T-0 time
         limitTwoWeeks: true,
     };
     // const missionOverride = null;

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -14,19 +14,24 @@ body:
 
 <img src="/current/sls-pad-sunset-ocean-hero.jpg" alt="Photo of the NASA SLS rocket at sunset on pad LC-39B taken on a Star Fleet boat tour" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
 
-Star Fleet is ready to go out once again for sunset boat trips to see the NASA Space Launch System rocket on LC-39B as it prepares for the historic Artemis 1 mission.
+Star Fleet will be going out for launch viewing boat trips for Artemis 1, where we will be at a closer viewing location just outside the launch hazard area, with a clear view of the pad about 10 mi / 16 km away, with a much more favorable angle to the easterly trajectory relative to any land-based locations.
+
+We will also be offering sunset boat trips to see the NASA Space Launch System rocket on LC-39B as it prepares for the historic Artemis 1 mission.
 Join us to see the world's most powerful completed rocket as it stands tall on its launch pad for its very first launch!
 
-We are also going out for a launch viewing boat trip for Artemis 1, where (safety zones allowing) we will be at a closer viewing location just outside the launch hazard area, with a clear view of the pad about 10 mi / 16 km away, with a much more favorable angle to the easterly trajectory relative to any land-based locations.
+**UPDATE:** Launch viewing tickets for the second launch attempt on Saturday, September 3 at 2:17 PM EDT (18:17 UTC) are now available!
+Passengers who booked tickets for the previous attempt will receive a 10% discount on this one; check your emails for special links with the discounted price.
+Also, in response to customer feedback to make things smoother for everyone at checkin, we will be offering separate tickets for the upper and main decks, so if you are able to snag one of the former, you'll be guaranteed a spot on it.
+Additionally, we'll be booking everyone initially on the Canaveral Princess, which has the largest upper deck size relative to its capacity, and a PA/sound system for launch audio and updates.
 
-**UPDATE:** Both pre-launch and launch tickets are now SOLD OUT yet again, and unfortunately it doesn't look like there are any more large ocean-rated boats we haven't yet booked at this time, and we have a very long waitlist of passengers in case any spots do become available.
-For those who have booked, you should have received an email with your ticket and more information, and we will be sending a reminder late today or early tomorrow with some additional information and reminders as we proceed closer to launch.
+We may be able to offer more pre-launch trips to go see the rocket up close on the pad, depending on interest—send us a call or text to let us know if you are.
 
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
 
 <h2 id="countdown" style="letter-spacing: 3px; text-align: center !important; margin-top: 1rem;">Check back soon!</h2>
-<a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em;">SOLD OUT</button></a>
+<a id="book-now-button" href="https://book.stripe.com/bIYaEN7lO2FPehqeV1" style="; display: none;"><button class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 14em;">Book Upper Deck</button></a>
+<a id="book-now-button-2" href="https://book.stripe.com/14k7sB0Xq6W5gpyeUX" style="; display: none;"><button class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 14em;">Book Main Deck</button></a>
 
 <script type="text/javascript">
 "use strict"
@@ -37,7 +42,7 @@ Number.prototype.pad = function(size) {
 };
 function updateTimer() {
     var currentTime        = new Date().getTime() / 1000;
-    var futureTime         = 0;
+    var futureTime         = 100000;
     var timeRemaining      = futureTime - currentTime;
     var minute             = 60;
     var hour               = 60 * 60;
@@ -52,6 +57,7 @@ function updateTimer() {
     } else if (futureTime < currentTime) {
         $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224");
         document.getElementById("book-now-button").style.display = "inherit";
+        document.getElementById("book-now-button-2").style.display = "inherit";
     } else if (futureTime > currentTime) {
         $('#countdown').html("Tickets Available In T-" + dayFloor.pad() + ":" + hourFloor.pad() + ":" + minuteFloor.pad() + ":" + secondFloor.pad());
     }
@@ -63,16 +69,41 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 <!-- <div style="margin-top: 50px;"><iframe style="width: 100%; height: 480px;" src="https://www.google.com/maps/d/u/0/embed?mid=1C-tpUOP1-KClf1sPJfrPXh1g9A4k0rg7"></iframe></div> -->
 
 
+
+## NASA SLS Artemis 1 Launch Boat Viewing
+
+<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
+
+**Status**: AVAILIBLE<br>
+**Price**: $90 (main deck), $99 (upper deck)<br>
+**Launch Time**: Saturday, September 3 at 2:17 PM EDT (18:17 UTC)<br>
+**Key Times**: Checkin 11:45 AM EDT | Boarding 12:15 PM EDT | Departure 12:45 PM EDT<br>
+**Location**: *Princess Fishing*, 670 Glen Cheek Dr, Cape Canaveral FL 32920<br>
+
+* Watch the SLS rocket, the world's most powerful, launch for the 1st time on Artemis 1
+* See a clear view of the pad from just outside the hazard area, ≈16 km / ≈10 mi away
+* Get an exclusive angle from along the rocket's ocean-bound trajectory
+* View from a larger vessel (Canaverl Princess/Orlando Princess) with a top observation deck
+* Free parking, a guaranteed spot and no need to show up many hours early
+<br>
+<br>
+**IMPORTANT:** *Tickets are generally non-refundable; please see the [details page](/details) before booking for more information about our refund, transfer and scrub/delay policies.*
+<br>
+<br>
+
+
+
+
 <img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 45px; margin-right: 40px; margin-bottom:0; float: left;">
 
 
 ## SLS Launch Pad Sunset Trip
 
-**Price**: $120 per person (all-included)<br>
-**Dates**: Friday-Sunday 26, 27 (SOLD OUT), 28 (SOLD OUT) 2022<br>
+**Price**: $130 per person<br>
+**Dates**: TBD<br>
 **Trip Time**: 6:00 PM - 9:00 PM EDT<br>
 **Key Times**: Checkin T-30 min | Boarding T-15 min | Departure T-0 min<br>
-**Location**: Sunrise Marina, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
+**Location**: Orlando Princess, 670 Glen Cheek Dr, Cape Canaveral FL 32920<br>
 
 * See NASA's new SLS moon rocket, the most powerful in the world, standing on its launch pad for the historic Artemis 1 launch, from an up-close vantage point and a unique angle
 * Chance to see a SpaceX Falcon 9 on its adjacent launch pad (subject to launch schedules)
@@ -81,52 +112,6 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 * View many sites of interest in Port Canaveral harbor and along the Cape
 * Travel on a fast, modern 12 or 6 passenger deep-sea charter vessel
 * Additional trips may be made available based on passenger demand
-<br>
-<br>
-
-
-
-## SLS/Falcon 9 Tour + SpaceX Launch Viewing
-
-<img src="/current/sls-and-falcon9-ocean.jpg" alt="Photo featuring both the NASA SLS rocket and the SpaceX Falcon 9 rocket on adjacent pads, taken on a Star Fleet boat tour" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: right;">
-
-**Status**: SOLD OUT<br>
-**Price**: $130 per person (guided), $120 per person (unguided)<br>
-**Date/Time**: Saturday August 27, 2022, 6:15 PM - 10:15 PM EDT<br>
-**Key Times**: Checkin D-30 min | Boarding D-15 min | Departure D-0 min<br>
-**Location**: Sunrise Marina, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
-
-* Everything on the SLS Launch Pad Sunset Trip
-* Expertly guided tour with space personality Julia Bergeron (optional extra)
-* See a SpaceX Falcon 9 standing ready for launch on pad 39A*
-* Get exclusive photos of the SLS and Falcon 9 rockets together at sunset*
-* After the main tour, watch the SpaceX Starlink 4-23 launch at 9:53 PM from the boat*
-* *IMPORTANT NOTE: If current launch schedules hold, which are subject to change without warning.<br>
-  If the launch is delayed, the Star Fleet trip will still go out as scheduled.
-<br>
-<br>
-
-
-
-## NASA SLS Artemis 1 Launch Boat Viewing
-
-<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
-
-**Status**: SOLD OUT<br>
-**Price**: $95<br>
-**Launch Time**: Monday, August 29 at 8:33 AM EDT (12:33 UTC)<br>
-**Key Times**: Checkin 6:00 AM EDT | Boarding 6:30 AM EDT | Departure 7:00 AM EDT<br>
-**Locations**: *Orlando Princess*, 670 Glen Cheek Dr, Cape Canaveral FL 32920<br>
-               *Sunrise Marina (Double O)*, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
-
-* Watch the SLS rocket, the world's most powerful, launch for the 1st time on Artemis 1
-* See a clear view of the pad from just outside the hazard area, ≈16 km / ≈10 mi away
-* Get an exclusive angle from along the rocket's ocean-bound trajectory
-* View from a larger vessel (Orlando Princess/Ocean Obsession) with a top observation deck
-* Free parking, a guaranteed spot and no need to show up many hours early
-<br>
-<br>
-**IMPORTANT:** *Tickets are generally non-refundable; please see the [details page](/details) before booking for more information about our refund, transfer and scrub/delay policies.*
 <br>
 <br>
 

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -20,11 +20,14 @@ We will also be offering sunset boat trips to see the NASA Space Launch System r
 Join us to see the world's most powerful completed rocket as it stands tall on its launch pad for its very first launch!
 
 **UPDATE:** Launch viewing tickets for the second launch attempt on Saturday, September 3 at 2:17 PM EDT (18:17 UTC) are now available!
-Passengers who booked tickets for the previous attempt will receive a 10% discount on this one; check your emails for special links with the discounted price.
+Passengers who booked tickets for the previous attempt will receive a 15% discount on this one; check your emails for special links with the discounted price.
 Also, in response to customer feedback to make things smoother for everyone at checkin, we will be offering separate tickets for the upper and main decks, so if you are able to snag one of the former, you'll be guaranteed a spot on it.
 Additionally, we'll be booking everyone initially on the Canaveral Princess, which has the largest upper deck size relative to its capacity, and a PA/sound system for launch audio and updates.
 
 We may be able to offer more pre-launch trips to go see the rocket up close on the pad, depending on interest—send us a call or text to let us know if you are.
+
+**REVISED DELAY/SCRUB POLICY**: Per the insistence of our captains, as well as to reduce uncertainty and simplify planning for our passengers and ourselves, we have had to implement a streamlined scrub policy for attempts going forward.
+Please read the [details page](/details) for more information.
 
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
@@ -74,7 +77,6 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 
 <img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
 
-**Status**: AVAILIBLE<br>
 **Price**: $90 (main deck), $99 (upper deck)<br>
 **Launch Time**: Saturday, September 3 at 2:17 PM EDT (18:17 UTC)<br>
 **Key Times**: Checkin 11:45 AM EDT | Boarding 12:15 PM EDT | Departure 12:45 PM EDT<br>
@@ -85,9 +87,10 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 * Get an exclusive angle from along the rocket's ocean-bound trajectory
 * View from a larger vessel (Canaverl Princess/Orlando Princess) with a top observation deck
 * Free parking, a guaranteed spot and no need to show up many hours early
+* If scrubbed prior to checkin, ticket will be converted to a launchpad tour on same time/boat
 <br>
 <br>
-**IMPORTANT:** *Tickets are generally non-refundable; please see the [details page](/details) before booking for more information about our refund, transfer and scrub/delay policies.*
+**REVISED DELAY/SCRUB POLICY:** *Tickets are generally non-refundable; please see the [details page](/details) before booking for more information about our refund, transfer and scrub/delay policies, which have been revised since the previous attempt.*
 <br>
 <br>
 

--- a/content/details/contents.lr
+++ b/content/details/contents.lr
@@ -18,41 +18,40 @@ Please ensure you read, understand and agree to everything here to ensure everyo
 
 ### Reserving your spot
 
-In order to reserve your spot on the boats, you *must* click the `Book` button on the `Tickets` page in the navigation bar above, follow the indicated steps, and pay the ticket price.
+In order to reserve your spot on the boats, you *must* click the `Book` button on the [Tickets page](/current), follow the indicated steps, and pay the ticket price.
 For the avoidance of doubt, anything else, including any verbal or written communication from us, does not constitute a reservation, confirmation or ticket.
 Due to very high demand and a limited number of slots, we unfortunately *cannot* hold your spot for you without a confirmed payment.
 Your confirmation email constitutes your ticket and proof of payment; if you do not successfully receive one (including in your spam/junk folder) after 10 minutes, then please contact us to ensure your payment is received and you are in our system.
 
 
-### Transferring your ticket
+### Transferring/refunding your ticket
 
-If you later realize you can't make it, either due to a personal commitment or a launch delay, you are free to sell/trade your spot with someone else.
-We will work with you to facilitate a trade or other arrangement with one of the many individuals wanting a ticket at any given time.
-While the tickets are non-refundable in the event the launch trip occurs as scheduled or on a scrub/delay day (see below for scrub/delay policy), we may make exceptions for special circumstances, but that cannot be guaranteed due to the non-refundable deposits we are required to pay to the captains we charter, and the significant risk involved.
+* If you inform us within 24 hours of purchase that you would like to cancel your ticket, you will be refunded in full, provided it was purchased at least 5 days in advance of the launch time, or within 24 hours of tickets being made available, whichever is later.
+* If you later realize you can't make it for any reason, you are free to sell/trade your spot(s) with anyone else.
+* We can work with you to facilitate a trade or other arrangement with one of the many individuals wanting a ticket at any given time, though we cannot guarantee this will always be possible, especially at the last minute.
+* If your transfer/refund request is received 24 hours or more before the check-in time, we will attempt to fill your spot on a best effort basis, and if we can, your ticket will be refunded; however, this *cannot* be guaranteed.
 
 
-### Delays/scrubs/refunds
+### Delays/scrubs
 
-If the launch is scrubbed or delayed anytime before we actually leave the dock (approximately one hour prior to the current launch time), your tickets will remain valid for any future launch time, including multiple attempts if necessary.
-
-We will do everything possible to ensure we do not leave the dock if a scrub is expected.
-However, once we do, due to the fact that the captain, crew and vessel have already done their part and would fulfilled their responsibilities and thus we owe them payment, we cannot offer a refund in this case.
-We will still go out to get a unique view of the rocket, see marine life, view the other historic Cape launch facilities, and make the best of the situation.
-
-If for any reason the launch either occurs or is rescheduled and we do not go out, e.g. unlikely event of an unforeseen emergency or serious technical issue with one of the boats, unsafe weather not sufficient to scrub the launch, a lengthy (≈>2 week) or indefinite delay/complete cancellation of the launch, your money will be refunded, minus any non-refundable portion of the credit card processing fee.
+* Your tickets remain valid and non-refundable for the launch day you purchased them for, so long as the boats are able to go out on that date and time.
+* You will be fully refunded in the unlikely event the boats are not able to go out, e.g. due to unsafe weather conditions (which would likely also scrub the launch) or an unexpected mechanical issue with one of the boats.
+* If a delay/scrub is officially announced at any point prior to the checkin/boarding time, the trip will be automatically converted to a launchpad tour up the coast to see see the rocket on the pad and the other historic and active CCSFS and KSC launch sites, on the same time and boat (subject to range and weather safety constraints).
+* If the scrub occurs during/after checkin/boarding or once on the boat, we will continue with the trip as scheduled, viewing the rocket and the other CCSFS pads from a safe distance, to make the most of the experience.
+* We offer a 10% discount on any future attempts for the same rocket within the same launch period to any passenger who booked a previous launch trip where the launch was scrubbed.
 
 
 ### Checkin and departure time
 
-Please have your entire party present and accounted for at the checkin location a minimum of *one hour prior to the most recent announced departure time*, which is in turn typically two hours prior to the current official launch time.
-We *strongly recommend* you leave more time to ensure you get a free parking spot and to account for unexpected delays due to the high traffic volume expected; there will plenty for you to do once you're there including getting food at Grills, observing Mr. Steven, the Crew Dragon mockup and the booster crane at the SpaceX dock across the channel, and other local attractions.
-At one hour prior to departure, online reservations will be closed and in-person checkin will begin; walkups and standbys will be accepted at this time.
+Please have your entire party present and accounted for at the checkin location a minimum of *one hour prior to the most recent announced departure time*, which is in turn typically at least two hours prior to the current official launch time.
+We *strongly recommend* you leave more time to ensure you get a free parking spot and to account for unexpected delays due to the high traffic volume expected; there will plenty for you to do once you're there including getting food at Grills, observing the SpaceX droneships, boosters and fleet right across the channel, and other local attractions.
+At one hour prior to departure, online reservations will be closed and in-person checkin will begin; walkups and standbys may be accepted at this time, but cannot be guaranteed due to high demand.
 
-We will be checking people in and giving out colored wristbands to keep track of what boat you are on; *you will need one to board your boat* and the captains will be checking for the correct color to make sure you get on your desired vessel.
-If you use our own reservation system to purchase tickets, it will provide you a QR code that we will scan on check-in shortly before departure.
+We will be checking people in and giving out paper tickets and/or colored wristbands (launch/boat dependent) to keep track of what boat you are on; *you will need one to board your boat* and the captains will be checking for the correct ticket/wristband to make sure you get on your desired vessel.
+If you use our reservation system to purchase tickets, it will send you an email that will constitute your boarding pass.
 Simply print this and bring it with you, or display it on your mobile device for us to scan.
-Otherwise, if you've booked through our payment gateway or directly with a Star Fleet Officer, we'll just look up your name for you.
-At 30 minutes to go, we will move to the dock and line up to board our respective vessels.
+Otherwise, if you've booked directly with a Star Fleet Officer, we'll just look up your name for you.
+At the designated boarding time, typically 30 minutes prior to departure, we will have boarded our respective vessels.
 If you are not checked in by this time, you will be in danger of *loosing your spot to standbys*.
 If an emergency arises, please contact one of us immediately to maximize the possibility that arrangements can be made.
 Due to the number of people on the trip, we will _not_ be able to delay our departure past the announced departure time, so *please* try to be on time to avoid having to forfeit your seat.

--- a/content/faq/contents.lr
+++ b/content/faq/contents.lr
@@ -41,7 +41,7 @@ In the past, a number of people have offered rides from local airports to the bo
 
 ### What do I need to do to reserve my spot?
 
-Simply click the "Reserve Now" link in the navigation bar above, and our system will walk you through the rest.
+Simply click the `Book` button on the [Tickets page](/current), and our system will walk you through the rest.
 Importantly, we do require paying for your ticket up-front, to avoid no-shows and ensure the limited number of spots available go to those committed to attending the launch.
 
 
@@ -54,40 +54,39 @@ The ticket price covers everything (aside from any separately-listed items), inc
 
 Some other companies offer trips that only go out a short ways from the Port, or can only go in the Indian/Bannana river, offering a view little better than what can be seen by free or inexpensive land-based alternatives.
 By contrast, our faster, safer and sturdier vessels often travel 15 km / 10 mi or more from the port to reach the optimal viewing position for any given launch, as determined by launch-viewing veterans and local experts.
+
 Furthermore, we often offer live launch commentary, pre-launch trips to see Cape Canaveral's many historic launch pads (including an exclusive up-close-and-personal view of the rocket on the pad usually only available to a small number of press and VIPs), expert viewing advice, and a number of extra goodies, along with excellent service and interaction.
 Through partnering with the Space Coast Launch Ambassadors volunteer organization, we aim to foster more than just business, but a community of space fans young and old, and help educate and inspire them along the way.
 
 
 ### Will you keep my party together?
 
-Yes, we will make every effort to keep your party together, unless you request otherwise.
+Yes, we will keep your party together, so long as you book your tickets under the same name.
+If not, we will do our best to keep multiple groups together if you let us know at least 24 hours in advance of launch, but we cannot guarantee it unless you book in one group.
 
 
-### What happens if the launch is delayed/scrubbed before we leave the dock?
+### What happens if the launch is delayed/scrubbed before checkin?
 
-If the launch is scrubbed or delayed anytime before we actually leave the dock (approximately one hour prior to the current launch time), your tickets will remain valid for any future launch time, including multiple attempts if necessary.
-If you are unable to make the new launch time due to extenuating circumstances, we may in specific situations be able to refund your ticket on a case by case basis.
-While thus far, we've usually been able to help people redeem, sell or refund their ticket, we cannot guarantee it to ensure we still have enough passengers to go out at our negotiated prices and avoid a large personal financial loss, given we are doing this as a community service rather than a primary profit making business.
+If a delay/scrub is officially announced at any point prior to the checkin/boarding time, the trip will be automatically converted to a launchpad tour up the coast to see see the rocket on the pad and the other historic and active CCSFS and KSC launch sites, on the same time and boat (subject to range and weather safety constraints).
+We also offer a 10% discount on future attempts of the same launch to anyone who booked such a trip.
 
 
-### What about if it scrubs after we leave port?
+### What about if it scrubs after checkin/while on the boat?
 
-We will do everything possible to ensure this is not the case.
-However, unfortunately due to the fact that the captain, crew and vessel have already done their part and would fulfilled their responsibilities for nothing, we cannot offer a refund in this case.
-We will still go out to get a unique view of the rocket, see marine life, view the other historic Cape launch facilities, and make the best of the situation.
-For those able to go out for further launch attempt, we may be able to offer a discount in certain situations.
+While we will not normally be able to offer a full launch pad tour in this case due to range safety constraints, we will still go out to get a unique view of the rocket, see marine life, view the other historic Cape launch facilities, and give everyone the best experience we can.
+We also offer a 10% discount on future attempts of the same launch to anyone who booked such a trip.
 
 
 ### If the boats aren't able to go out at all, do we get refunded?
 
-If the launch either occurs or is rescheduled and we do not go out, e.g. unlikely event of an unforeseen emergency or serious technical issue with one of the boats, unsafe weather not sufficient to scrub the launch, a lengthy (÷>2 week) or indefinite delay/complete cancellation of the launch, your money will be fully refunded, minus any non-refundable portion of the credit card processing fee.
+Yes; in the unlikely event of unsafe weather or a serious technical issue with one of the boats, your money will be fully refunded.
 
 
 ### Do I need to bring anything to prove I reserved a spot?
 
-If you use our own online reservation system (`book.star-fleet.tours`, it will provide you a QR code that we will scan on check-in shortly before departure.
+If you use our online reservation system, we will send you a boarding pass for your party at least 24 hours prior to departure.
 Simply print this and bring it with you, or display it on your mobile device at the dock.
-If you book the trip through a dedicated link to our external payment platform, or directly with one of our Star Fleet Officers, we'll keep track of that for you, and we'll just need your name at checkin to confirm.
+If you book the trip directly with one of our Star Fleet Officers, we'll keep track of that for you, and we'll just need your name at checkin to confirm.
 
 
 


### PR DESCRIPTION
Update for the viewing trips for the second launch attempt of the NASA SLS Artemis 1 mission, and also update and streamline the scrub/refund policy as well as a few other details.