### PR TITLE
Update to evergreen launch status page & add Insta links

### DIFF
--- a/assets/static/js/custom-scripts.js
+++ b/assets/static/js/custom-scripts.js
@@ -22,7 +22,7 @@ https://opensource.org/licenses/MIT
     // Otherwise, specify the absence of a missionOverride:
     const missionOverride = {
         missionName: "NASA SLS Artemis 1 Launch",
-        launchAt: 1668402420, // the UNIX timestamp of the projected T-0 time
+        launchAt: 1668578640, // the UNIX timestamp of the projected T-0 time
         limitTwoWeeks: true,
     };
     // const missionOverride = null;

--- a/assets/static/js/custom-scripts.js
+++ b/assets/static/js/custom-scripts.js
@@ -21,8 +21,8 @@ https://opensource.org/licenses/MIT
     //
     // Otherwise, specify the absence of a missionOverride:
     const missionOverride = {
-        missionName: "SpaceX Falcon Heavy USSF-44 Launch",
-        launchAt: 1667310060, // the UNIX timestamp of the projected T-0 time
+        missionName: "NASA SLS Artemis 1 Launch",
+        launchAt: 1668402420, // the UNIX timestamp of the projected T-0 time
         limitTwoWeeks: true,
     };
     // const missionOverride = null;

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -14,15 +14,14 @@ body:
 
 <img src="/current/sls-pad-sunset-ocean-hero.jpg" alt="Photo of the NASA SLS rocket at sunset on pad LC-39B taken on a Star Fleet boat tour" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
 
-Star Fleet will be going out for launch viewing boat trips for the next attempt of Artemis 1, which is currently poised on its pad for midnight liftoff on *Monday, November 14 at 12:07 AM EST (05:07 UTC)*.
+If the weather cooperates, Star Fleet will be going out for launch viewing boat trips for the next attempt of Artemis 1, which is currently poised on its pad for midnight liftoff on *Monday, November 14 at 12:07 AM EST (05:07 UTC)*.
 We expect to be at a viewing location just outside the launch hazard area, with a clear view of the pad approximately 10 mi / 16 km away (hazard zone dependent), with a much more favorable angle to the easterly trajectory relative to land-based locations.
 
-We also plan to offer sunset boat trips for the weekend prior to the launch (assuming the weather cooperates) to see the Space Launch System rocket on LC-39B as it prepares for its historic mission.
-Join us to see the world's most powerful completed rocket as it stands tall on its launch pad for its very first launch!
+Additionally, we planned to offer sunset boat trips for the weekend prior to the launch to see the rocket up close on its pad, but these are currently on hold due to rough seas forecast this week through this weekend.
 
-**UPDATE:** As of *Monday, November 7*, we are currently preparing our booking system and confirming final plans with the boat operators, in order to open up tickets in the next couple days.
-As we've done previously, we'll update this page in the next couple days with a live countdown to the availability of tickets at least ≈24 hours prior to tickets going live, and announce the same on our social media.
-Sea conditions are forecast to be too rough for safe and comfortable pre-launch pad tours this weekend, but we plan to run them next weekend if the weather cooperates, and will announce them once confirmed.
+**UPDATE:** As of *Monday, November 7*, we have things prepared to start offering tickets for the launch viewing trip.
+However, we are currently monitoring the possibility of rough sea conditions to ensure we are likely to have a safe and comfortable experience, as well as possible delays to the launch date due to Tropical Storm Nicole, so are holding off on formally booking tickets for the trip right away.
+If and when we can confirm we'll be going out, likely in the next few days, we'll update this page with a live countdown to the availability of tickets at least ≈24 hours prior to tickets going live, and keep you up to date in the meantime on our social media.
 
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
@@ -71,7 +70,7 @@ The **upper deck** tickets includes full access to the main deck, and adds on th
 <br>
 
 
-<h2 id="countdown" style="letter-spacing: 2px; text-align: center !important; font-size: 2rem; margin-top: 0.5rem;">Check back soon!</h2>
+<h2 id="countdown" style="text-align: center !important; font-size: 2rem; letter-spacing: 2px; margin-top: 0.5rem;">Check back soon!</h2>
 <a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 0.5em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
 <a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; margin-bottom: 0.5em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
 
@@ -95,7 +94,7 @@ function updateTimer() {
     var secondFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour - minuteFloor * minute));
     var countdownCompleted = "Completed";
     if (futureTime == 0) {
-        $('#countdown').html("Ticket countdown coming soon!");
+        $('#countdown').html("Check back soon!");
     } else if (futureTime <= currentTime) {
         /* $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224"); */
         document.getElementById("countdown").style.display = "none";
@@ -115,7 +114,7 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 ## SLS Launch Pad Sunset Trip
 
 **Price**: $140 per person<br>
-**Dates**: Friday, November 11 - Sunday, November 13<br>
+**Dates**: TBD, due to seas/weather<br>
 **Trip Time**: 4:00 PM - 7:00 PM EST<br>
 **Key Times**: Checkin T-30 min | Boarding T-15 min | Departure T-0 min<br>
 **Location**: *TBD* Port Canaveral, Cape Canaveral FL 32920<br>
@@ -126,10 +125,12 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 * Enjoy a unique ocean-side view of every active CCAFS and KSC launch pad
 * View many sites of interest in Port Canaveral harbor and along the Cape
 * Travel on a fast, modern 6-12 passenger deep-sea charter vessel
-* Additional trips may be made available based on passenger demand
+* Trips are on hold pending safe and comfortable boating conditions
 <br>
 
-<span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Call/text 321-209-2224 for pre-launch trips</span>
+<span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; letter-spacing: 2px; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Check back soon!</span>
+
+<!-- <span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Call/text 321-209-2224 for pre-launch trips</span> -->
 
 
 ---

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -14,14 +14,12 @@ body:
 
 <img src="/current/sls-pad-sunset-ocean-hero.jpg" alt="Photo of the NASA SLS rocket at sunset on pad LC-39B taken on a Star Fleet boat tour" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
 
-If the weather cooperates, Star Fleet will be going out for launch viewing boat trips for the next attempt of Artemis 1, which is currently poised on its pad for midnight liftoff on *Monday, November 14 at 12:07 AM EST (05:07 UTC)*.
-We expect to be at a viewing location just outside the launch hazard area, with a clear view of the pad approximately 10 mi / 16 km away (hazard zone dependent), with a much more favorable angle to the easterly trajectory relative to land-based locations.
+Currently, the SLS rocket for the Artemis 1 mission remains poised on its pad for a scheduled early morning liftoff on *Monday, November 14 at 1:04 AM EST (06:04 UTC)*.
+We are currently planning to go out on a special sunset boat trip to see it up close on the pad the evening before, as well as arranging private launch viewing for interested passengers.
 
-Additionally, we planned to offer sunset boat trips for the weekend prior to the launch to see the rocket up close on its pad, but these are currently on hold due to rough seas forecast this week through this weekend.
-
-**UPDATE:** As of *Monday, November 7*, we have things prepared to start offering tickets for the launch viewing trip.
-However, we are currently monitoring the possibility of rough sea conditions to ensure we are likely to have a safe and comfortable experience, as well as possible delays to the launch date due to Tropical Storm Nicole, so are holding off on formally booking tickets for the trip right away.
-If and when we can confirm we'll be going out, likely in the next few days, we'll update this page with a live countdown to the availability of tickets at least ≈24 hours prior to tickets going live, and keep you up to date in the meantime on our social media.
+**UPDATE:** As of *Sunday, November 13*, due to continued uncertainty about the launch date holding and limited boat availability for a 1-3 AM launch, coupled with a family medical situation, we're unfortunately unable to hold a full launch viewing trip.
+However, we will be offering pre-launch sunset trips to see the rocket up close on the pad the evening before launch night.
+You can also contact us and we'll help connect you with one of our captain for a private charter, or suggest other great viewing locations.
 
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
@@ -36,9 +34,9 @@ Thanks!*
 
 <img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
 
-**Price**: $90 (main deck), $99 (upper deck)<br>
-**Launch Time**: Monday, November 14 at 12:07 AM EST (05:07 UTC)<br>
-**Key Times**: Checkin 9:30 AM EST | Boarding 10:00 AM EST | Departure 10:30 AM EST<br>
+**Price**: NOT AVAILIBLE AT THIS TIME<br>
+**Launch Time**: Monday, November 16 at 1:04 AM EST (06:04 UTC)<br>
+**Key Times**: Checkin T-2.5 h | Boarding T-2 h | Departure T-1.5 h<br>
 **Location**: *Sunrise Marina*, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
 
 * Watch the SLS rocket, the world's most powerful, launch for the 1st time on Artemis 1
@@ -70,7 +68,7 @@ The **upper deck** tickets includes full access to the main deck, and adds on th
 <br>
 
 
-<h2 id="countdown" style="text-align: center !important; font-size: 2rem; letter-spacing: 2px; margin-top: 0.5rem;">Check back soon!</h2>
+<h2 id="countdown" style="text-align: center !important; font-size: 2rem; letter-spacing: 2px; margin-top: 0;">Check back soon!</h2>
 <a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 0.5em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
 <a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; margin-bottom: 0.5em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
 
@@ -94,7 +92,7 @@ function updateTimer() {
     var secondFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour - minuteFloor * minute));
     var countdownCompleted = "Completed";
     if (futureTime == 0) {
-        $('#countdown').html("Check back soon!");
+        $('#countdown').html("For private launch vewing, <br>call/text 321-209-2224");
     } else if (futureTime <= currentTime) {
         /* $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224"); */
         document.getElementById("countdown").style.display = "none";
@@ -114,10 +112,10 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 ## SLS Launch Pad Sunset Trip
 
 **Price**: $140 per person<br>
-**Dates**: TBD, due to seas/weather<br>
-**Trip Time**: 4:00 PM - 7:00 PM EST<br>
+**Dates**: November 15, 2022<br>
+**Trip Time**: 4:00 PM - 8:00 PM EST<br>
 **Key Times**: Checkin T-30 min | Boarding T-15 min | Departure T-0 min<br>
-**Location**: *TBD* Port Canaveral, Cape Canaveral FL 32920<br>
+**Location**: 726 Scallop Dr, Port Canaveral, FL 32920<br>
 
 * See NASA's new SLS moon rocket, the most powerful in the world, standing on its launch pad for the historic Artemis 1 launch, from an up-close vantage point and a unique angle
 * Chance to view other active rockets on their pads (subject to launch schedules)
@@ -125,12 +123,13 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 * Enjoy a unique ocean-side view of every active CCAFS and KSC launch pad
 * View many sites of interest in Port Canaveral harbor and along the Cape
 * Travel on a fast, modern 6-12 passenger deep-sea charter vessel
-* Trips are on hold pending safe and comfortable boating conditions
+* Additional trips may be scheduled if the launch date is delayed
 <br>
 
-<span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; letter-spacing: 2px; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Check back soon!</span>
+<!-- <span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; letter-spacing: 2px; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Check back soon!</span> -->
 
-<!-- <span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Call/text 321-209-2224 for pre-launch trips</span> -->
+<span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; line-height: 1.2em;
+letter-spacing: 2px; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">For pre-launch trips, <br>call/text 321-209-2224 </span>
 
 
 ---

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -6,33 +6,34 @@ short_title: Tickets
 ---
 special_link: true
 ---
-full_title: SpaceX Falcon Heavy USSF-44 Launch & Sunset Pad Viewing
+full_title: NASA SLS Artemis 1 Launch
 ---
 body:
 
 <div id="page-body-countdown-container"></div>
 
-<img src="/current/fh-landing-day.jpg" alt="Falcon Heavy twin side boosters landing at LZ-1 and LZ-2 during the day"  style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
+<img src="/current/sls-pad-sunset-ocean-hero.jpg" alt="Photo of the NASA SLS rocket at sunset on pad LC-39B taken on a Star Fleet boat tour" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
 
-After three full years, the wait is finally over for the next flight of the Falcon Heavy, the world's most powerful operational rocket!
-It'll be launching on **Tuesday, November 1 at 9:41 AM EDT** (13:41 UTC) with the USSF-44 top-secret national security payload for the US Space Force, in its first operational government mission.
-Star Fleet will be going out for both the launch itself, and a sunset boat trip to see the rocket up close on the pad the evening before.
+Star Fleet will be going out for launch viewing boat trips for the next attempt of Artemis 1, which is currently poised on its pad for midnight liftoff on *Monday, November 14 at 12:07 AM EST (05:07 UTC)*.
+We expect to be at a viewing location just outside the launch hazard area, with a clear view of the pad approximately 10 mi / 16 km away (hazard zone dependent), with a much more favorable angle to the easterly trajectory relative to land-based locations.
 
-This launch will feature a uniquely spectacular twin booster Return to Launch Site landing, and we'll be in an ideal position to view it.
-Our current nominal planned viewing location, as with previous Falcon Heavy missions, provides both the closest and clearest view of the booster landing available anywhere.
-It has a clear view of both pads all the way down to the landing legs, and is around or less than 4 mi / 6 km from the landing trajectory as the twin boosters light their engines and arc in almost right over our heads, and around or less than 6 mi / ≈9 km from the landing pad itself.
-Distance from the launch pad is around 12-14 mi / 19-22 km, but also with a clear view and a more favorable angle to the trajectory than any land-based spot, at a closest approach of around 9-11 mi / 14-17 km.
-However, depending on the exact position of the hazard zones and subject to range and USCG clearance, we may actually be able to get up to several miles closer to both launch and landing, which is currently pending confirmation.
+We also plan to offer sunset boat trips for the weekend prior to the launch (assuming the weather cooperates) to see the Space Launch System rocket on LC-39B as it prepares for its historic mission.
+Join us to see the world's most powerful completed rocket as it stands tall on its launch pad for its very first launch!
 
-Meanwhile, our sunset boat trip will feature an up close and personal view of the rocket standing tall on the pad, backlit by the setting sun, from as close as 500 yd/m away;
-plus, you'll get to see a unique angle on the other KSC and CCSFS pads on the way there and back as well.
+**UPDATE:** As of *Monday, November 7*, we are currently preparing our booking system and confirming final plans with the boat operators, in order to open up tickets in the next couple days.
+As we've done previously, we'll update this page in the next couple days with a live countdown to the availability of tickets at least ≈24 hours prior to tickets going live, and announce the same on our social media.
+Sea conditions are forecast to be too rough for safe and comfortable pre-launch pad tours this weekend, but we plan to run them next weekend if the weather cooperates, and will announce them once confirmed.
+
+**REVISED DELAY/SCRUB POLICY**: Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
+At or after that point, if the launch scrubs, we will be committed with the boat operator to go out and see the rocket lit up on the pad, and we will be unable to refund the tickets.
+However, we can offer a 10% discount and priority access to booking to passengers who go out with us on further attempts within the same launch period.
 
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
 
 <h2 id="countdown" style="letter-spacing: 3px; text-align: center !important; margin-top: 1rem;">Check back soon!</h2>
-<a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 20em;">Upper Deck SOLD OUT</button></a>
-<a id="book-now-button-2" href="https://book.stripe.com/cN26ox35y1BL5KU00e" style="; display: none;"><button class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 20em;">Book Lower Deck</button></a>
+<a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
+<a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
 
 <script type="text/javascript">
 "use strict"
@@ -43,7 +44,7 @@ Number.prototype.pad = function(size) {
 };
 function updateTimer() {
     var currentTime        = new Date().getTime() / 1000;
-    var futureTime         = 100000;
+    var futureTime         = 0;
     var timeRemaining      = futureTime - currentTime;
     var minute             = 60;
     var hour               = 60 * 60;
@@ -54,9 +55,9 @@ function updateTimer() {
     var secondFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour - minuteFloor * minute));
     var countdownCompleted = "Completed";
     if (futureTime == 0) {
-        $('#countdown').html("Tickets sold out, sorry");
-    } else if (futureTime < currentTime) {
-        $('#countdown').html("To book <i>pad tour</i> tickets,<br>call or text 321-209-2224");
+        $('#countdown').html("Ticket countdown coming soon!");
+    } else if (futureTime <= currentTime) {
+        $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224");
         document.getElementById("book-now-button").style.display = "inherit";
         document.getElementById("book-now-button-2").style.display = "inherit";
     } else if (futureTime > currentTime) {
@@ -70,42 +71,44 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 <!-- <div style="margin-top: 50px;"><iframe style="width: 100%; height: 480px;" src="https://www.google.com/maps/d/u/0/embed?mid=1C-tpUOP1-KClf1sPJfrPXh1g9A4k0rg7"></iframe></div> -->
 
 
-<img src="/current/fh-launch-day.jpg" alt="Falcon Heavy launching during the day, from a public domain USAF photo" style="margin-top: 60px; margin-left: 40px; margin-bottom:0; float: right;">
 
-## SpaceX Falcon Heavy USSF-44 Launch & Landing Boat Viewing
+## NASA SLS Artemis 1 Launch Boat Viewing
 
-**Price**: $95 (main deck), $125 (upper deck)<br>
-**Launch Time**: Tuesday, November 1 at 9:41 AM EDT (13:41 UTC)<br>
-**Key Times**: Checkin 7:30 AM EDT | Boarding 8:00 AM EDT | Departure 8:30 AM EDT<br>
+<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
+
+**Price**: $90 (main deck), $99 (upper deck)<br>
+**Launch Time**: Monday, November 14 at 12:07 AM EST (05:07 UTC)<br>
+**Key Times**: Checkin 9:30 AM EST | Boarding 10:00 AM EST | Departure 10:30 AM EST<br>
 **Location**: *Sunrise Marina*, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
 
-* Closest and clearest viewing for landing available anywhere
-* Clear view of both LZ-1 and LZ-2 down to the landing legs
-* Only <≈4 mi / <≈6 km from landing trajectory and <≈6 mi / <≈9 km from pads
-* Favorable angle downrange of trajectory, only ≈9-11 mi / <≈14-17 km away
-* Clear view of launch pad at <≈12-14 mi / <≈19-22 km distance
-* Free parking, a guaranteed spot and no need to show up many hours early
+* Watch the SLS rocket, the world's most powerful, launch for the 1st time on Artemis 1
+* See a clear pad view across the water, ≈16 km / ≈10 mi away (hazard zone dependent)
+* Get an exclusive angle from along the rocket's ocean-bound trajectory
+* View from a larger vessel (Princesses/Double-O II) with a top observation deck
+* Free parking, a guaranteed viewing spot and no need to show up more than 2 hours early
+* If scrubbed prior to checkin, ticket still valid for the next attempt (in same launch period)
 <br>
 <br>
-**DELAY/SCRUB POLICY:** *Tickets are generally non-refundable.*<br>
-See our [details page](/details) for more information.
+**REVISED DELAY/SCRUB POLICY**: Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
+At or after that point, if the launch scrubs, we will be committed with the boat operator to go out and see the rocket lit up on the pad, and we will be unable to refund the tickets.
+However, we can offer a 10% discount and priority access to booking to passengers who go out with us on further attempts within the same launch period.
 <br>
 <br>
 
 
+<img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 60px; margin-left: 20px; margin-right: 0px; margin-bottom:0; float: right;">
 
-<img src="/current/fh-pad-water.jpg" alt="Close-up photo of the SpaceX Falcon Heavy rocket on its pad LC-39A, taken on a Star Fleet boat tour" style="margin-top: 55px; margin-right: 40px; margin-bottom:100px; float: left;">
 
-
-## Falcon Heavy LC-39A Sunset Pad Trip
+## SLS Launch Pad Sunset Trip
 
 **Price**: $140 per person<br>
-**Dates**: Monday, October 31<br>
-**Trip Time**: 5:00 PM - 9:00 PM EDT<br>
+**Dates**: Friday, November 11 - Sunday, November 13<br>
+**Trip Time**: 4:00 PM - 7:00 PM EST<br>
 **Key Times**: Checkin T-30 min | Boarding T-15 min | Departure T-0 min<br>
-**Location**: *Blue Points Marina*, 726 Scallop Dr, Port Canaveral, FL 32920<br>
+**Location**: *TBD* Port Canaveral, Cape Canaveral FL 32920<br>
 
-* Experience the SpaceX Falcon Heavy, the world's most powerful operational rocket
+* See NASA's new SLS moon rocket, the most powerful in the world, standing on its launch pad for the historic Artemis 1 launch, from an up-close vantage point and a unique angle
+* Chance to view other active rockets on their pads (subject to launch schedules)
 * See historic Apollo and Shuttle sites, including LC-34, LC-36 and LC-39A/B
 * Enjoy a unique ocean-side view of every active CCAFS and KSC launch pad
 * View many sites of interest in Port Canaveral harbor and along the Cape

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -32,38 +32,17 @@ Thanks!*
 
 ## NASA SLS Artemis 1 Launch Boat Viewing
 
-<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
+<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 5px; margin-right: 40px; margin-bottom:0; float: left;">
 
 **Price**: NOT AVAILIBLE AT THIS TIME<br>
 **Launch Time**: Monday, November 16 at 1:04 AM EST (06:04 UTC)<br>
 **Key Times**: Checkin T-2.5 h | Boarding T-2 h | Departure T-1.5 h<br>
-**Location**: *Sunrise Marina*, 505 Glen Cheek Dr, Cape Canaveral FL 32920<br>
 
-* Watch the SLS rocket, the world's most powerful, launch for the 1st time on Artemis 1
-* See a clear pad view across the water, ≈16 km / ≈10 mi away (hazard zone dependent)
-* Get an exclusive angle from along the rocket's ocean-bound trajectory
-* View from a larger vessel (Princesses/Double-O II) with a top observation deck
-* Free parking, a guaranteed viewing spot and no need to show up more than 2 hours early
-* If scrubbed prior to checkin, ticket still valid for the next attempt (in same launch period)
-<br>
+Currently, the SLS rocket for the Artemis 1 mission remains poised on its pad for a scheduled early morning liftoff on *Monday, November 14 at 1:04 AM EST (06:04 UTC)*.
+However, due to continued uncertainty about the launch date holding and limited boat availability for a 1-3 AM launch, coupled with a family medical situation, we're unfortunately unable to hold a full launch viewing trip.
 
-
-### Revised Delay/Scrub Policy
-
-Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
-At or after that point, if the launch scrubs, we will be committed with the boat operator to go out and see the rocket lit up on the pad, and we will be unable to refund the tickets.
-However, we can offer a 10% discount and priority access to booking to passengers who go out with us on further attempts within the same launch period.
-
-
-### Upper Deck vs. Main Deck Tickets
-
-Per coast guard safety regulations, our larger vessels can only allow a limited number of people on the upper deck.
-However, we ensure levels provide a great launch viewing experience, as both are open to the sky, and we have the captains position the boat and track the rocket as it launches and lands so people on both decks have a great unobstructed view of all the action.
-
-The **main deck** has more space per person and seating on all boats, both indoors and outdoors, as well as more protection from the sun.
-It also has easier access to the bow, galley and restrooms, and is more accessable for passengers of differing abilities, as well as being a bit more stable for those who are motion-sensitive.
-
-The **upper deck** tickets includes full access to the main deck, and adds on the upper deck with a 360 degree all-around vista, a slightly better view of the pads and downrange landings, and seating on the Princess boats (though not OO2).
+We will be offering pre-launch sunset trips to see the rocket up close on the pad the evening before launch night.
+You can also contact us and we'll help connect you with one of our captain for a private charter, or suggest other great viewing locations.
 <br>
 <br>
 

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -24,48 +24,9 @@ Join us to see the world's most powerful completed rocket as it stands tall on i
 As we've done previously, we'll update this page in the next couple days with a live countdown to the availability of tickets at least ≈24 hours prior to tickets going live, and announce the same on our social media.
 Sea conditions are forecast to be too rough for safe and comfortable pre-launch pad tours this weekend, but we plan to run them next weekend if the weather cooperates, and will announce them once confirmed.
 
-**REVISED DELAY/SCRUB POLICY**: Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
-At or after that point, if the launch scrubs, we will be committed with the boat operator to go out and see the rocket lit up on the pad, and we will be unable to refund the tickets.
-However, we can offer a 10% discount and priority access to booking to passengers who go out with us on further attempts within the same launch period.
-
 *Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
 Thanks!*
 
-<h2 id="countdown" style="letter-spacing: 3px; text-align: center !important; margin-top: 1rem;">Check back soon!</h2>
-<a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
-<a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
-
-<script type="text/javascript">
-"use strict"
-Number.prototype.pad = function(size) {
-    var s = String(this);
-    while (s.length < (size || 2)) {s = "0" + s;}
-    return s;
-};
-function updateTimer() {
-    var currentTime        = new Date().getTime() / 1000;
-    var futureTime         = 0;
-    var timeRemaining      = futureTime - currentTime;
-    var minute             = 60;
-    var hour               = 60 * 60;
-    var day                = 60 * 60 * 24;
-    var dayFloor           = Math.floor(timeRemaining / day);
-    var hourFloor          = Math.floor((timeRemaining - dayFloor * day) / hour);
-    var minuteFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour) / minute);
-    var secondFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour - minuteFloor * minute));
-    var countdownCompleted = "Completed";
-    if (futureTime == 0) {
-        $('#countdown').html("Ticket countdown coming soon!");
-    } else if (futureTime <= currentTime) {
-        $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224");
-        document.getElementById("book-now-button").style.display = "inherit";
-        document.getElementById("book-now-button-2").style.display = "inherit";
-    } else if (futureTime > currentTime) {
-        $('#countdown').html("Tickets Available In T-" + dayFloor.pad() + ":" + hourFloor.pad() + ":" + minuteFloor.pad() + ":" + secondFloor.pad());
-    }
-};
-var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
-</script>
 
 
 <!-- <div style="margin-top: 50px;"><iframe style="width: 100%; height: 480px;" src="https://www.google.com/maps/d/u/0/embed?mid=1C-tpUOP1-KClf1sPJfrPXh1g9A4k0rg7"></iframe></div> -->
@@ -110,7 +71,45 @@ The **upper deck** tickets includes full access to the main deck, and adds on th
 <br>
 
 
-<img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 60px; margin-left: 20px; margin-right: 0px; margin-bottom:0; float: right;">
+<h2 id="countdown" style="letter-spacing: 2px; text-align: center !important; font-size: 2rem; margin-top: 0.5rem;">Check back soon!</h2>
+<a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 0.5em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
+<a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; margin-bottom: 0.5em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
+
+<script type="text/javascript">
+"use strict"
+Number.prototype.pad = function(size) {
+    var s = String(this);
+    while (s.length < (size || 2)) {s = "0" + s;}
+    return s;
+};
+function updateTimer() {
+    var currentTime        = new Date().getTime() / 1000;
+    var futureTime         = 0;
+    var timeRemaining      = futureTime - currentTime;
+    var minute             = 60;
+    var hour               = 60 * 60;
+    var day                = 60 * 60 * 24;
+    var dayFloor           = Math.floor(timeRemaining / day);
+    var hourFloor          = Math.floor((timeRemaining - dayFloor * day) / hour);
+    var minuteFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour) / minute);
+    var secondFloor        = Math.floor((timeRemaining - dayFloor * day - hourFloor * hour - minuteFloor * minute));
+    var countdownCompleted = "Completed";
+    if (futureTime == 0) {
+        $('#countdown').html("Ticket countdown coming soon!");
+    } else if (futureTime <= currentTime) {
+        /* $('#countdown').html("To book <em>pre-launch</em> trips,<br>call or text 321-209-2224"); */
+        document.getElementById("countdown").style.display = "none";
+        document.getElementById("book-now-button").style.display = "inherit";
+        document.getElementById("book-now-button-2").style.display = "inherit";
+    } else if (futureTime > currentTime) {
+        $('#countdown').html("Tickets Available In T-" + dayFloor.pad() + ":" + hourFloor.pad() + ":" + minuteFloor.pad() + ":" + secondFloor.pad());
+    }
+};
+var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
+</script>
+
+
+<img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 50px; margin-left: 20px; margin-right: 0px; margin-bottom:0; float: right;">
 
 
 ## SLS Launch Pad Sunset Trip
@@ -129,7 +128,8 @@ The **upper deck** tickets includes full access to the main deck, and adds on th
 * Travel on a fast, modern 6-12 passenger deep-sea charter vessel
 * Additional trips may be made available based on passenger demand
 <br>
-<br>
+
+<span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Call/text 321-209-2224 for pre-launch trips</span>
 
 
 ---

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -88,10 +88,24 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 * Free parking, a guaranteed viewing spot and no need to show up more than 2 hours early
 * If scrubbed prior to checkin, ticket still valid for the next attempt (in same launch period)
 <br>
-<br>
-**REVISED DELAY/SCRUB POLICY**: Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
+
+
+### Revised Delay/Scrub Policy
+
+Note that due to the time of this launch, we've been able to relax our previous scrub policy for this attempt, such that tickets remain fully valid for a rescheduled attempt so long as the launch is officially aborted/scrubbed prior to the designated checkin time.
 At or after that point, if the launch scrubs, we will be committed with the boat operator to go out and see the rocket lit up on the pad, and we will be unable to refund the tickets.
 However, we can offer a 10% discount and priority access to booking to passengers who go out with us on further attempts within the same launch period.
+
+
+### Upper Deck vs. Main Deck Tickets
+
+Per coast guard safety regulations, our larger vessels can only allow a limited number of people on the upper deck.
+However, we ensure levels provide a great launch viewing experience, as both are open to the sky, and we have the captains position the boat and track the rocket as it launches and lands so people on both decks have a great unobstructed view of all the action.
+
+The **main deck** has more space per person and seating on all boats, both indoors and outdoors, as well as more protection from the sun.
+It also has easier access to the bow, galley and restrooms, and is more accessable for passengers of differing abilities, as well as being a bit more stable for those who are motion-sensitive.
+
+The **upper deck** tickets includes full access to the main deck, and adds on the upper deck with a 360 degree all-around vista, a slightly better view of the pads and downrange landings, and seating on the Princess boats (though not OO2).
 <br>
 <br>
 

--- a/content/current/contents.lr
+++ b/content/current/contents.lr
@@ -6,50 +6,54 @@ short_title: Tickets
 ---
 special_link: true
 ---
-full_title: NASA SLS Artemis 1 Launch
+full_title: Upcoming Missions
 ---
 body:
 
 <div id="page-body-countdown-container"></div>
 
-<img src="/current/sls-pad-sunset-ocean-hero.jpg" alt="Photo of the NASA SLS rocket at sunset on pad LC-39B taken on a Star Fleet boat tour" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
+<img src="/fh-boat-launch.jpg" alt="Photograph of the Falcon Heavy launching the Arabsat mission" style="display: block; margin-left: auto; margin-right: auto; margin-top: 5px; margin-bottom: 20px;">
 
-Currently, the SLS rocket for the Artemis 1 mission remains poised on its pad for a scheduled early morning liftoff on *Monday, November 14 at 1:04 AM EST (06:04 UTC)*.
-We are currently planning to go out on a special sunset boat trip to see it up close on the pad the evening before, as well as arranging private launch viewing for interested passengers.
+Star Fleet is currently planning larger trips for the multiple potential remaining Falcon Heavy launches planned for 2023, the next being the NASA Pysche mission currently scheduled for October 5 at 10:38 AM EDT (14:38 UTC).
+If there's interest, we will likely run smaller, less-formal community trips for the upcoming NASA Crew-7 mission to the International Space Station currently scheduled for August 17 at 6:56 AM EDT (10:56 UTC), as well as other notable launches and those involving Return to Launch Site landings.
+Additionally, for those curious, we will be going out for the NASA SLS Artemis 2 crew mission to the moon, currently scheduled for no earlier than November 2024.
+Stay tuned here and on our social media for updates as we get closer to the scheduled dates.
 
-**UPDATE:** As of *Sunday, November 13*, due to continued uncertainty about the launch date holding and limited boat availability for a 1-3 AM launch, coupled with a family medical situation, we're unfortunately unable to hold a full launch viewing trip.
-However, we will be offering pre-launch sunset trips to see the rocket up close on the pad the evening before launch night.
-You can also contact us and we'll help connect you with one of our captain for a private charter, or suggest other great viewing locations.
-
-*Stay tuned to our [Twitter feed](https://twitter.com/StarFleetTours) for the latest important updates and to get in touch with us directly (see below for more links).
+*Be sure to check our [Twitter](https://twitter.com/StarFleetTours), [Instagram](https://instagram.com/starfleettours/) and [Facebook](https://www.facebook.com/starfleettours/) for the latest updates on all our activities, as well as announcements of smaller/informal trips, and feel free to reach out over DM if you're interested in a private charter for a specific mission.
 Thanks!*
-
-
 
 <!-- <div style="margin-top: 50px;"><iframe style="width: 100%; height: 480px;" src="https://www.google.com/maps/d/u/0/embed?mid=1C-tpUOP1-KClf1sPJfrPXh1g9A4k0rg7"></iframe></div> -->
 
 
 
-## NASA SLS Artemis 1 Launch Boat Viewing
+<img src="/current/crew-dragon-liftoff-night.jpg" alt="Photograph of a Falcon 9 rocket with a Crew Dragon capsule lifting off at night from LC-39A" style="margin-top: 20px; margin-right: 40px; margin-bottom:0; float: left;">
 
-<img src="/current/sls-launch-graphic.jpg" alt="NASA-generated rendering of the Space Launch System launching" style="margin-top: 5px; margin-right: 40px; margin-bottom:0; float: left;">
 
-**Price**: NOT AVAILIBLE AT THIS TIME<br>
-**Launch Time**: Monday, November 16 at 1:04 AM EST (06:04 UTC)<br>
-**Key Times**: Checkin T-2.5 h | Boarding T-2 h | Departure T-1.5 h<br>
+## Rocket Launch Viewing
 
-Currently, the SLS rocket for the Artemis 1 mission remains poised on its pad for a scheduled early morning liftoff on *Monday, November 14 at 1:04 AM EST (06:04 UTC)*.
-However, due to continued uncertainty about the launch date holding and limited boat availability for a 1-3 AM launch, coupled with a family medical situation, we're unfortunately unable to hold a full launch viewing trip.
+**Price**: ≈$100/person (dependent on boats availible)<br>
+**Launch Time**: **TBD**<br>
+**Key Times**: T-2 hours | T-1.5 hours | Departure T-1 hour<br>
+**Location**: Port Canaveral, Cape Canaveral FL 32920<br>
 
-We will be offering pre-launch sunset trips to see the rocket up close on the pad the evening before launch night.
-You can also contact us and we'll help connect you with one of our captain for a private charter, or suggest other great viewing locations.
+* Great location to view all the key events of the launch
+* Typically 4-5 miles / 6-8 km from launch or landing
+* Favorable angle downrange of launch trajectory
+* Direct view of LC-39A and many other historic CCAFS pads
+* Magical for night launches as light reflects off the water
+* Close by to SpaceX landing zones for booster landings
+* Free parking, a guaranteed spot and no need to show up many hours early
 <br>
 <br>
-
+**DELAY/SCRUB POLICY:** *Tickets are generally non-refundable.*<br>
+See our [details page](/details) for more information.
+<br>
+<br>
 
 <h2 id="countdown" style="text-align: center !important; font-size: 2rem; letter-spacing: 2px; margin-top: 0;">Check back soon!</h2>
 <a id="book-now-button" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 0.5em; width: 100%; max-width: 17em;">Book Upper Deck</button></a>
 <a id="book-now-button-2" href="" style="; display: none;"><button disabled class="content-button text-button" style="margin-top: 1em; margin-bottom: 0.5em; width: 100%; max-width: 17em;">Book Main Deck</button></a>
+<br>
 
 <script type="text/javascript">
 "use strict"
@@ -85,24 +89,22 @@ var countdownTimer = setInterval(function(){ updateTimer(); }, 1000);
 </script>
 
 
-<img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 50px; margin-left: 20px; margin-right: 0px; margin-bottom:0; float: right;">
+<img src="/current/sls-pad-sunset-ocean-portrait.jpg" alt="Close-up photo of the NASA SLS rocket at sunset on pad LC-39B with a flock of birds, taken on a Star Fleet boat tour" style="margin-top: 50px; margin-left: 20px; margin-right: 0px; margin-bottom:200px; float: right;">
 
+## Pre-Launch Pad Trip
 
-## SLS Launch Pad Sunset Trip
-
-**Price**: $140 per person<br>
-**Dates**: November 15, 2022<br>
-**Trip Time**: 4:00 PM - 8:00 PM EST<br>
+**Price**: ≈$100 per person (boat-dependent)<br>
+**Dates**: Typically ≈12-24 hours before launch<br>
+**Trip Time**: ≈3 hours<br>
 **Key Times**: Checkin T-30 min | Boarding T-15 min | Departure T-0 min<br>
-**Location**: 726 Scallop Dr, Port Canaveral, FL 32920<br>
+**Location**: Port Canaveral, Cape Canaveral FL 32920<br>
 
-* See NASA's new SLS moon rocket, the most powerful in the world, standing on its launch pad for the historic Artemis 1 launch, from an up-close vantage point and a unique angle
+* Get an exclusive, up-close look at the rocket and spacecraft on the pad unavailable from any other angle
 * Chance to view other active rockets on their pads (subject to launch schedules)
 * See historic Apollo and Shuttle sites, including LC-34, LC-36 and LC-39A/B
 * Enjoy a unique ocean-side view of every active CCAFS and KSC launch pad
 * View many sites of interest in Port Canaveral harbor and along the Cape
 * Travel on a fast, modern 6-12 passenger deep-sea charter vessel
-* Additional trips may be scheduled if the launch date is delayed
 <br>
 
 <!-- <span id="pre-launch-callout" style="display: block; text-align: center !important; font-size: 2rem; letter-spacing: 2px; font-family: 'bitsumishiregular', Raleway, 'DejaVu Sans', 'Open Sans', 'Liberation Sans', Helvetica, Arial, sans-serif; margin-top: 0rem;">Check back soon!</span> -->

--- a/star_fleet_tours.lektorproject
+++ b/star_fleet_tours.lektorproject
@@ -12,7 +12,7 @@ target = ghpages+https://star-fleet-tours/star-fleet-tours-website?cname=www.sta
 title = Star✦Fleet Tours
 content_lang = en-US
 author = Star✦Fleet Tours
-copyright = &copy; 2021 Star✦Fleet Tours
+copyright = &copy; 2023 Star✦Fleet Tours
 description = A collective of rocket enthusiasts dedicated to providing the most enjoyable, educational, and awe-inspiring launch viewing experience for visitors of all ages.
 keywords = rocket, space, spacex, tour, launch, boat, falcon
 favicon_path = /static/images/favicon.png
@@ -35,7 +35,7 @@ loader_enable = false
 nav_logo_path =
 nav_logo_text = Star✦Fleet Tours
 nav_extralinks = SCLA: https://scla.space/
-footer_links = Twitter: https://twitter.com/StarFleetTours, Facebook: https://www.facebook.com/starfleettours, Github: https://github.com/star-fleet-tours, Slack: https://spacexmeetups.slack.com/, Gitter: https://gitter.im/star-fleet-tours/public, Email: mailto:fleetcommand@star-fleet.tours
+footer_links = Instagram: https://instagram.com/starfleettours/, Twitter: https://twitter.com/StarFleetTours, Facebook: https://www.facebook.com/starfleettours, GitHub: https://github.com/star-fleet-tours, Slack: https://spacexmeetups.slack.com/, Gitter: https://gitter.im/star-fleet-tours/public, Email: mailto:fleetcommand@star-fleet.tours
 footer_license_name = CC-BY-SA 4.0 (Content); MIT (Code)
 footer_license_link = https://github.com/star-fleet-tours/star-fleet-tours-website/blob/master/LICENSE.txt
 gitter_room = star-fleet-tours/public


### PR DESCRIPTION
Updates the launch status page to give an overview of upcoming launches, generally-applicable information, and how to reach out to inquire about specific launches. Also updates the site to add our Instagram link to the main footer as well as in the body text, and bumps the copyright date. Finally, includes the previous history of the updates for the NASA SLS Artemis 1 mission's third series of launch attempts, for posterity.

Closes #29 